### PR TITLE
Set versions fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+notebooks/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:11
 
 ARG compile_cores=8
 
@@ -31,10 +31,10 @@ COPY openmc_install_scripts/Debian11/double_down-install.sh .
 RUN ./double_down-install.sh "$compile_cores"
 
 COPY openmc_install_scripts/Debian11/dagmc-install.sh .
-RUN ./dagmc-install.sh "$compile_cores"
+RUN DEBIAN_FRONTEND=noninteractive && ./dagmc-install.sh "$compile_cores"
 
 COPY openmc_install_scripts/Debian11/openmc-install.sh .
-RUN ./openmc-install.sh "$compile_cores"
+RUN DEBIAN_FRONTEND=noninteractive && ./openmc-install.sh "$compile_cores"
 
 #clean up a bit
 RUN rm *-install.sh
@@ -49,7 +49,7 @@ RUN sudo pip install --no-cache-dir requests jupyterlab
 RUN mkdir msre
 COPY msre_simple.h5m msre/
 COPY msre_control*.h5m msre/
-COPY msre_*.py msre/
+#COPY msre_*.py msre/
 RUN mkdir example_notebooks
 COPY MSRE.ipynb example_notebooks/
 ENV OPENMC_CROSS_SECTIONS=/home/usr/openmc/nuclear_data/mcnp_endfb71/cross_sections.xml

--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ This repository is created for the purpose of creating a docker conatiner which 
     Second, a number of windows features need to be turned on:![windows features](.images/WSL_2.png)
     
     Should you still have problems - please contact us (for instance by opening an issue in this repo) and we'll help you out.
+3. Jupiter notebook 
+ The default password for the jupyter notebook is 'docker'.

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker build -t copenhagenatomics/msre:0.1.0 .
+docker build -t copenhagenatomics/msre:0.1.1 .

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -9,4 +9,4 @@ if [ ! -d $mountdir ]; then
 	mkdir $mountdir
 fi
 
-docker run -it -p 8888:8888 -e JUPYTER_ENABLE_LAB=yes -e JUPYTER_TOKEN=docker -v ${PWD}/${mountdir}:/home/usr/notebooks copenhagenatomics/msre:0.1.0
+docker run -it -p 8888:8888 -e JUPYTER_ENABLE_LAB=yes -e JUPYTER_TOKEN=docker -v ${PWD}/${mountdir}:/home/usr/notebooks copenhagenatomics/msre:0.1.1

--- a/run_docker_daemon.sh
+++ b/run_docker_daemon.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+PWD=`pwd`
+
+mountdir=$1
+if [ "a$1" == "a" ]; then
+	mountdir=notebooks
+fi
+if [ ! -d $mountdir ]; then
+	mkdir $mountdir
+fi
+
+docker run -d --restart unless-stopped -p 8888:8888 -e JUPYTER_ENABLE_LAB=yes -e JUPYTER_TOKEN=docker -v ${PWD}/${mountdir}:/home/usr/notebooks copenhagenatomics/msre:0.1.1


### PR DESCRIPTION
- Fix the debian version in the docker file, to be compatible with the openmc install scripts
- add the 'notebooks' folder in a gitignore.
- add script to run docker as a daemon